### PR TITLE
Fix assignment of string literals to node (conversion to bool)

### DIFF
--- a/include/mstch/mstch.hpp
+++ b/include/mstch/mstch.hpp
@@ -118,6 +118,8 @@ struct node : std::variant<
   node() : base_type(std::in_place_type<std::monostate>) {}
 
   explicit node(const char* value) : base_type(std::in_place_type<std::string>, value) {}
+  
+  node& operator=(const char* value) { return *this = std::string{value}; }
 
   base_type& base() { return *this; }
   base_type const& base() const { return *this; }


### PR DESCRIPTION
The explicit operator fixed creation of nodes with string literals, but assignments still converted to bool - i.e.

`context["title"] = "Hello World";`

was still broken, this pull request fixes it